### PR TITLE
Add build/test configs, restore globbing, register plugins/themes, and default to guest

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+  },
+  fullyParallel: true,
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run build && npm run preview -- --host 127.0.0.1 --port 4173',
+    url: 'http://127.0.0.1:4173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/src/core/kernel.ts
+++ b/src/core/kernel.ts
@@ -100,7 +100,7 @@ const kernel = {} as Kernel;
 const vfs = createVfs();
 kernel.vfs = vfs;
 
-let currentName = 'skogix';
+let currentName = 'guest';
 let bootTime = Date.now();
 let cwd = HOME;
 let cachedHostname = resolveHostname();

--- a/src/core/shell-glob.ts
+++ b/src/core/shell-glob.ts
@@ -1,0 +1,205 @@
+import type { IdentityLike, Vfs } from './vfs.js';
+
+const GLOB_META = new Set(['*', '?', '[']);
+const REGEXP_META = /[\\^$.*+?()[\]{}|]/g;
+
+const escapeRegExp = (s: string): string => s.replace(REGEXP_META, '\\$&');
+
+const unescapeGlob = (s: string): string => s.replace(/\\(.)/g, '$1');
+
+const hasUnescapedMeta = (s: string): boolean => {
+  let escaped = false;
+  for (const ch of s) {
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (ch === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (GLOB_META.has(ch)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const normalizePattern = (
+  pattern: string,
+  cwd: string,
+  identity: IdentityLike
+) => {
+  let expanded = pattern;
+  if (expanded === '~') {
+    expanded = `/home/${identity.name}`;
+  } else if (expanded.startsWith('~/')) {
+    expanded = `/home/${identity.name}${expanded.slice(1)}`;
+  }
+
+  const absolute = expanded.startsWith('/');
+  const prefixed = absolute ? expanded : `${cwd || '/'}/${expanded}`;
+  const parts = prefixed.split('/').filter(Boolean);
+  const out: string[] = [];
+  for (const part of parts) {
+    if (part === '.') {
+      continue;
+    }
+    if (part === '..') {
+      out.pop();
+      continue;
+    }
+    out.push(part);
+  }
+
+  return {
+    absolute,
+    absPattern: `/${out.join('/')}`,
+    cwd: cwd === '/' ? '/' : cwd.replace(/\/$/, ''),
+  };
+};
+
+const displayPath = (abs: string, absolute: boolean, cwd: string): string => {
+  if (absolute) {
+    return abs;
+  }
+  if (cwd === '/') {
+    return abs.slice(1) || '.';
+  }
+  if (abs === cwd) {
+    return '.';
+  }
+  if (abs.startsWith(`${cwd}/`)) {
+    return abs.slice(cwd.length + 1);
+  }
+  return abs;
+};
+
+export function compileSegment(segment: string): RegExp {
+  let pattern = '^';
+  for (let i = 0; i < segment.length; i++) {
+    const ch = segment[i] as string;
+    if (ch === '\\') {
+      const next = segment[i + 1];
+      pattern += escapeRegExp(next ?? ch);
+      if (next !== undefined) {
+        i++;
+      }
+      continue;
+    }
+    if (ch === '*') {
+      pattern += '.*';
+      continue;
+    }
+    if (ch === '?') {
+      pattern += '.';
+      continue;
+    }
+    if (ch === '[') {
+      let j = i + 1;
+      let cls = '';
+      if (segment[j] === '!' || segment[j] === '^') {
+        cls += '^';
+        j++;
+      }
+      if (segment[j] === ']') {
+        cls += '\\]';
+        j++;
+      }
+      let closed = false;
+      for (; j < segment.length; j++) {
+        const c = segment[j] as string;
+        if (c === ']') {
+          closed = true;
+          break;
+        }
+        if (c === '\\') {
+          const next = segment[j + 1];
+          cls += escapeRegExp(next ?? c);
+          if (next !== undefined) {
+            j++;
+          }
+          continue;
+        }
+        cls += c === '^' ? '\\^' : c;
+      }
+      if (closed) {
+        pattern += `[${cls}]`;
+        i = j;
+      } else {
+        pattern += '\\[';
+      }
+      continue;
+    }
+    pattern += escapeRegExp(ch);
+  }
+  pattern += '$';
+  return new RegExp(pattern);
+}
+
+export function globExpand(
+  pattern: string,
+  vfs: Vfs,
+  cwd: string,
+  identity: IdentityLike
+): string[] {
+  if (!hasUnescapedMeta(pattern)) {
+    return [unescapeGlob(pattern)];
+  }
+
+  const normalized = normalizePattern(pattern, cwd, identity);
+  const parts = normalized.absPattern.split('/').filter(Boolean);
+  const matches: string[] = [];
+
+  const walk = (base: string, index: number): void => {
+    if (index >= parts.length) {
+      matches.push(base || '/');
+      return;
+    }
+
+    const segment = parts[index] as string;
+    if (!hasUnescapedMeta(segment)) {
+      const next =
+        base === '/'
+          ? `/${unescapeGlob(segment)}`
+          : `${base}/${unescapeGlob(segment)}`;
+      const resolved = vfs.resolve(next, '/', identity);
+      if (resolved.ok) {
+        walk(resolved.abs, index + 1);
+      }
+      return;
+    }
+
+    const stat = vfs.stat(base || '/', '/', identity);
+    if (!stat.ok || stat.type !== 'dir') {
+      return;
+    }
+    const listing = vfs.list(base || '/', '/', identity);
+    if (!listing.ok) {
+      return;
+    }
+
+    const matcher = compileSegment(segment);
+    const includeDotfiles = segment.startsWith('.');
+    for (const [name] of listing.entries) {
+      if (!includeDotfiles && name.startsWith('.')) {
+        continue;
+      }
+      if (!matcher.test(name)) {
+        continue;
+      }
+      const next = base === '/' ? `/${name}` : `${base}/${name}`;
+      walk(next, index + 1);
+    }
+  };
+
+  walk('/', 0);
+
+  if (matches.length === 0) {
+    return [unescapeGlob(pattern)];
+  }
+
+  return matches
+    .sort((a, b) => a.localeCompare(b))
+    .map(path => displayPath(path, normalized.absolute, normalized.cwd));
+}

--- a/src/core/vfs.ts
+++ b/src/core/vfs.ts
@@ -1,6 +1,6 @@
 export const ROOT = 'root';
 export const GUEST = 'guest';
-export const HOME = '/home/skogix';
+export const HOME = '/home/guest';
 
 export const ENOENT = 'ENOENT';
 export const EACCES = 'EACCES';

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,0 +1,60 @@
+import type { PluginInstall } from '../core/kernel.js';
+import bashHistory from './bash-history.js';
+import bootSplash from './boot-splash.js';
+import colortest from './colortest.js';
+import coreutils from './coreutils.js';
+import demo from './demo.js';
+import dev from './dev.js';
+import etc from './etc.js';
+import find from './find.js';
+import fortune from './fortune.js';
+import fsutils from './fsutils.js';
+import home from './home.js';
+import identity from './identity.js';
+import about from './me/about.js';
+import contact from './me/contact.js';
+import pwnProfile from './me/pwn-profile.js';
+import neofetch from './neofetch.js';
+import posthog from './posthog.js';
+import proc from './proc.js';
+import projects from './projects.js';
+import pwn from './pwn.js';
+import rmEgg from './rm-egg.js';
+import root from './root.js';
+import sysinfo from './sysinfo.js';
+import text from './text.js';
+import theme from './theme.js';
+import usr from './usr.js';
+import varPlugin from './var.js';
+import version from './version.js';
+
+export const plugins: PluginInstall[] = [
+  etc,
+  home,
+  root,
+  usr,
+  varPlugin,
+  proc,
+  dev,
+  pwn,
+  about,
+  contact,
+  pwnProfile,
+  coreutils,
+  fsutils,
+  rmEgg,
+  text,
+  find,
+  identity,
+  sysinfo,
+  version,
+  neofetch,
+  projects,
+  fortune,
+  colortest,
+  theme,
+  bashHistory,
+  bootSplash,
+  demo,
+  posthog,
+];

--- a/src/plugins/me/about.ts
+++ b/src/plugins/me/about.ts
@@ -8,7 +8,7 @@ const aboutText =
   'find me at [github.com/SkogAI](https://github.com/SkogAI)';
 
 const install: PluginInstall = kernel => {
-  kernel.vfs.appendDir('/home/skogix', {
+  kernel.vfs.appendDir('/home/guest', {
     'about.txt': asGuest(file(aboutText)),
   });
 

--- a/src/plugins/me/contact.ts
+++ b/src/plugins/me/contact.ts
@@ -1,0 +1,20 @@
+import type { PluginInstall } from '../../core/kernel.js';
+import { aliasCat } from '../../core/shell.js';
+import { asGuest, file } from '../../core/vfs.js';
+
+const contactText =
+  'github: [github.com/SkogAI](https://github.com/SkogAI)\n' +
+  'email: skogai@proton.me\n';
+
+const install: PluginInstall = kernel => {
+  kernel.vfs.appendDir('/home/guest', {
+    'contact.txt': asGuest(file(contactText)),
+  });
+
+  kernel.installExecutable('/bin/contact', {
+    describe: 'contact links',
+    exec: aliasCat('~/contact.txt'),
+  });
+};
+
+export default install;

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -1,0 +1,36 @@
+import catppuccinMocha from './catppuccin-mocha.js';
+import crt from './crt.js';
+import dracula from './dracula.js';
+import espresso from './espresso.js';
+import graphite from './graphite.js';
+import gruvbox from './gruvbox.js';
+import matrix from './matrix.js';
+import nord from './nord.js';
+import skogai from './skogai.js';
+import synthwave from './synthwave.js';
+import tokyoNight from './tokyo-night.js';
+
+export type Theme = {
+  name: string;
+  describe: string;
+  css: string;
+  backgroundImage?: string;
+  overlayBackground?: string;
+  overlayBlur?: string;
+};
+
+export const DEFAULT_THEME = 'skogai';
+
+export const themes: Theme[] = [
+  skogai,
+  tokyoNight,
+  crt,
+  dracula,
+  synthwave,
+  matrix,
+  nord,
+  gruvbox,
+  catppuccinMocha,
+  graphite,
+  espresso,
+];

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  root: 'src',
+  build: {
+    target: 'esnext',
+    outDir: '../dist',
+    emptyOutDir: true,
+  },
+  test: {
+    include: ['../tests/unit/**/*.test.ts'],
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
### Motivation
- Ensure the app can be built and tested locally by providing Vite/Vitest and Playwright configuration, and restore missing runtime registries and defaults.
- Reintroduce robust shell globbing so commands that rely on patterns (`*`, `?`, character classes, escaped literals, tilde, dotfile rules) behave correctly.
- Make the runtime defaults and user-facing files align with the guest identity and expose a contact command.

### Description
- Add `vite.config.ts` and `playwright.config.ts` to configure build/test roots, output target, unit-test discovery, and e2e webserver/project settings.
- Implement `src/core/shell-glob.ts` with `globExpand` and `compileSegment`, including metacharacter detection, escaped-literal handling, tilde expansion, directory checks, dotfile filtering, sorted results, and display-path normalization.
- Update `src/core/kernel.ts` to default the active identity to `guest`.
- Change `src/core/vfs.ts` `HOME` constant to `/home/guest` and update plugins to append `about`/`contact` files into `/home/guest`.
- Restore `src/plugins/index.ts` and `src/themes/index.ts` registries and add a new `src/plugins/me/contact.ts` plugin exposing a `/bin/contact` command.

### Testing
- Ran `npm run build` and a full Vite build completed successfully (success).
- Ran unit tests via `vitest` (`npm run test:unit`) where all unit tests passed (169 tests across 5 test files, success).
- Attempted Playwright e2e runs but they are blocked in this environment because Playwright browsers are not installed, so e2e was not completed (blocked).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18c61dae6883319061539df0d43a31)